### PR TITLE
Qualcomm AI Engine Direct - Fix dispatch_api_qualcomm_test

### DIFF
--- a/litert/vendors/qualcomm/dispatch/BUILD
+++ b/litert/vendors/qualcomm/dispatch/BUILD
@@ -88,6 +88,9 @@ cc_test(
         "no_oss",
         "notap",
     ],
+    data = [
+        ":dispatch_api_so",
+    ],
     deps = [
         ":dispatch_api",
         "@com_google_googletest//:gtest_main",


### PR DESCRIPTION
# What
Add `dispatch_api_so` back to generate `libLiteRtDispatch_Qualcomm.so` when building `//litert/vendors/qualcomm/dispatch:dispatch_api_qualcomm_test`

# Build
`bazel build -c opt --cxxopt=--std=c++17 --nocheck_visibility --config=android_arm64 //litert/vendors/qualcomm/dispatch:dispatch_api_qualcomm_test`

# Test
```
[----------] 4 tests from Qualcomm (799 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (799 ms total)
[  PASSED  ] 4 tests.
```